### PR TITLE
Eliminate circular dependencies in targets.

### DIFF
--- a/fort_depend.py
+++ b/fort_depend.py
@@ -77,7 +77,7 @@ def create_file_objs(files=None, macros={}):
 
 def get_uses(infile=None, macros={}):
     "Return which modules are used in infile after expanding macros"
-    p=re.compile("^\s*use\s*(?P<moduse>\w*)\s*(,)?\s*(only)?\s*(:)?.*?$",re.IGNORECASE).match
+    p=re.compile("^\s*use\s+(?P<moduse>\w*)\s*(,)?\s*(only)?\s*(:)?.*?$",re.IGNORECASE).match
 
     uses=[]
 
@@ -130,10 +130,10 @@ def get_depends(fob=[],m2f=[]):
         tmp=[]
         for j in i.uses:
             try:
-                tmp.append(m2f[j.lower()])
+                if m2f[j.lower()] != i.file_name:
+                    tmp.append(m2f[j.lower()])
             except:
                 print "\033[031mError\033[039m module \033[032m"+j+"\033[039m not defined in any files. Skipping..."
-
         deps[i.file_name]=tmp
 
     return deps


### PR DESCRIPTION
Check if a file depends on itself and not include it in the depends list. Also slight modification to use regex to not detect variables starting with use
